### PR TITLE
Add L2 norm

### DIFF
--- a/fasttext/fasttext.pyx
+++ b/fasttext/fasttext.pyx
@@ -5,6 +5,9 @@ from interface cimport loadModelWrapper
 from interface cimport FastTextModel
 from interface cimport Dictionary
 
+# numpy
+import numpy as np
+
 # Python/C++ standart libraries
 from libc.stdlib cimport malloc, free
 from libcpp.string cimport string
@@ -24,9 +27,12 @@ cdef class FastTextModelWrapper:
     def get_words(self):
         return self.words
 
-    def get_vector(self, word):
+    def get_vector(self, word, norm = False):
         word_bytes = bytes(word, 'utf-8')
-        return self.fm.getVectorWrapper(word_bytes)
+        vec = np.array(self.fm.getVectorWrapper(word_bytes))
+        if norm:
+            vec = vec / np.linalg.norm(vec)
+        return vec
 
     @property
     def dim(self):

--- a/fasttext/fasttext.pyx
+++ b/fasttext/fasttext.pyx
@@ -29,7 +29,7 @@ cdef class FastTextModelWrapper:
 
     def get_vector(self, word, norm = False):
         word_bytes = bytes(word, 'utf-8')
-        vec = np.array(self.fm.getVectorWrapper(word_bytes))
+        vec = self.fm.getVectorWrapper(word_bytes)
         if norm:
             vec = vec / np.linalg.norm(vec)
         return vec

--- a/fasttext/model.py
+++ b/fasttext/model.py
@@ -2,7 +2,6 @@
 import numpy as np
 
 
-
 class WordVectorModel(object):
     def __init__(self, model, words):
         self._model = model

--- a/fasttext/model.py
+++ b/fasttext/model.py
@@ -1,38 +1,44 @@
 # fastText Model representation in Python
 import numpy as np
-from numpy.linalg import norm
 
 
 class WordVectorModel(object):
     def __init__(self, model, words):
         self._model = model
         self.words = words
-        self.dim = model.dim;
-        self.ws = model.ws;
-        self.epoch = model.epoch;
-        self.min_count = model.minCount;
-        self.neg = model.neg;
-        self.word_ngrams = model.wordNgrams;
-        self.loss_name = model.lossName.decode('utf-8');
-        self.model_name = model.modelName.decode('utf-8');
-        self.bucket = model.bucket;
-        self.minn = model.minn;
-        self.maxn = model.maxn;
-        self.lr_update_rate = model.lrUpdateRate;
-        self.t = model.t;
+        self.dim = model.dim
+        self.ws = model.ws
+        self.epoch = model.epoch
+        self.min_count = model.minCount
+        self.neg = model.neg
+        self.word_ngrams = model.wordNgrams
+        self.loss_name = model.lossName.decode('utf-8')
+        self.model_name = model.modelName.decode('utf-8')
+        self.bucket = model.bucket
+        self.minn = model.minn
+        self.maxn = model.maxn
+        self.lr_update_rate = model.lrUpdateRate
+        self.t = model.t
+        self.norm = False
 
     def get_vector(self, word):
-        return self._model.get_vector(word)
+        return self._model.get_vector(word, norm=self.norm)
+
+    def set_vec_norm(self, state):
+        self.norm = state
 
     def __getitem__(self, word):
-        return self._model.get_vector(word)
+        return self._model.get_vector(word, norm=self.norm)
 
     def __contains__(self, word):
         return word in self.words
 
+    def __iter__(self):
+        for word in self.words:
+            yield word, self._model.get_vector(word, norm=self.norm)
+
     def cosine_similarity(self, first_word, second_word):
-        v1 = self.__getitem__(first_word)
-        v2 = self.__getitem__(second_word)
-        dot_product = np.dot(v1, v2)
-        cosine_sim = dot_product / (norm(v1) * norm(v2))
+        v1 = self._model.get_vector(first_word, norm=True)
+        v2 = self._model.get_vector(second_word, norm=True)
+        cosine_sim = np.dot(v1, v2)
         return cosine_sim

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+numpy
 Cython==0.24.1

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ extensions = [
 # Package details
 setup(
     name='fasttext',
-    version='0.5.19',
+    version='0.5.20',
     author='Bayu Aldi Yansyah',
     author_email='bayualdiyansyah@gmail.com',
     url='https://github.com/pyk/fastText.py',

--- a/test/cbow_test.py
+++ b/test/cbow_test.py
@@ -88,9 +88,9 @@ class TestCBOWModel(unittest.TestCase):
         self.assertEqual(len(model.get_vector('the')), dim)
 
         # Make sure L2 normalization is working as expected
-        self.assertGreater(abs(np.linalg.norm(model['the'])) - 1, 1e-5)
+        self.assertGreater(abs(np.linalg.norm(model['the']) - 1), 1e-5)
         model.set_vec_norm(True)
-        self.assertLess(abs(np.linalg.norm(model['the'])) - 1, 1e-5)
+        self.assertLess(abs(np.linalg.norm(model['the']) - 1), 1e-5)
         model.set_vec_norm(False)
 
         # Make sure we support unicode character

--- a/test/cbow_test.py
+++ b/test/cbow_test.py
@@ -80,9 +80,18 @@ class TestCBOWModel(unittest.TestCase):
         self.assertTrue(path.isfile(output + '.bin'))
         self.assertTrue(path.isfile(output + '.vec'))
 
+        # Make sure the model contains the word "the"
+        self.assertTrue("the" in model)
+
         # Make sure the vector have the right dimension
         self.assertEqual(len(model['the']), dim)
         self.assertEqual(len(model.get_vector('the')), dim)
+
+        # Make sure L2 normalization is working as expected
+        self.assertGreater(abs(np.linalg.norm(model['the'])) - 1, 1e-5)
+        model.set_vec_norm(True)
+        self.assertLess(abs(np.linalg.norm(model['the'])) - 1, 1e-5)
+        model.set_vec_norm(False)
 
         # Make sure we support unicode character
         unicode_str = 'Καλημέρα'

--- a/test/cbow_test.py
+++ b/test/cbow_test.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 import unittest
 from os import path
-
+import numpy as np
 import fasttext as ft
 
 cbow_file = path.join(path.dirname(__file__), 'cbow_params_test.bin')

--- a/test/skipgram_test.py
+++ b/test/skipgram_test.py
@@ -89,9 +89,9 @@ class TestSkipgramModel(unittest.TestCase):
         self.assertEqual(len(model.get_vector('the')), dim)
 
         # Make sure L2 normalization is working as expected
-        self.assertGreater(abs(np.linalg.norm(model['the'])) - 1, 1e-5)
+        self.assertGreater(abs(np.linalg.norm(model['the']) - 1), 1e-5)
         model.set_vec_norm(True)
-        self.assertLess(abs(np.linalg.norm(model['the'])) - 1, 1e-5)
+        self.assertLess(abs(np.linalg.norm(model['the']) - 1), 1e-5)
         model.set_vec_norm(False)
 
         # Make sure we support unicode character

--- a/test/skipgram_test.py
+++ b/test/skipgram_test.py
@@ -3,12 +3,13 @@
 from __future__ import unicode_literals
 import unittest
 from os import path
-
+import numpy as np
 import fasttext as ft
 
 skipgram_file = path.join(path.dirname(__file__), 'skipgram_params_test.bin')
 input_file = path.join(path.dirname(__file__), 'params_test.txt')
 output = path.join(path.dirname(__file__), 'generated_skipgram')
+
 
 # Test to make sure that skipgram interface run correctly
 class TestSkipgramModel(unittest.TestCase):
@@ -80,9 +81,18 @@ class TestSkipgramModel(unittest.TestCase):
         self.assertTrue(path.isfile(output + '.bin'))
         self.assertTrue(path.isfile(output + '.vec'))
 
+        # Make sure the model contains the word "the"
+        self.assertTrue("the" in model)
+
         # Make sure the vector have the right dimension
         self.assertEqual(len(model['the']), dim)
         self.assertEqual(len(model.get_vector('the')), dim)
+
+        # Make sure L2 normalization is working as expected
+        self.assertGreater(abs(np.linalg.norm(model['the'])) - 1, 1e-5)
+        model.set_vec_norm(True)
+        self.assertLess(abs(np.linalg.norm(model['the'])) - 1, 1e-5)
+        model.set_vec_norm(False)
 
         # Make sure we support unicode character
         unicode_str = 'Καλημέρα'


### PR DESCRIPTION
For now we have no direct access to the vectors.
Simpler option is to add an option to get norm vec when requested.
https://github.com/salestock/fastText.py/issues/14

When vec will be in numpy format, will be easier to manipulate...