### PR TITLE
Add target to upload and install from pypitest server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,14 @@ README.rst: README.md
 upload: README.rst
 	python setup.py sdist upload
 
+upload-to-pypitest: README.rst
+	python setup.py sdist upload -r pypitest
+.PHONY: upload-to-pypitest
+
+install-from-pypitest::
+	pip install -U --no-cache-dir -i https://testpypi.python.org/pypi fasttext
+.PHONY: install-from-pypitest
+
 install-dev: README.rst
 	python setup.py develop
 .PHONY: install-dev


### PR DESCRIPTION
The contributors will be able to upload the package to [Test PyPI Server](https://wiki.python.org/moin/TestPyPI) for testing purpose

To upload the package, use the following command:

```shell
make upload-to-pypitest
```

To install the package from test server, use the following command:

```shell
make install-from-pypitest
```

Make sure `~/.pypirc` configured properly