### PR TITLE
Fix #68: Not deallocate the log tables in train wrapper

### DIFF
--- a/fasttext/fasttext.pyx
+++ b/fasttext/fasttext.pyx
@@ -194,6 +194,7 @@ def train_wrapper(model_name, input_file, output, label_prefix, lr, dim, ws,
         raise IOError('fastText: output is not writeable!')
 
     # Initialize log & sigmoid tables
+    # The table is not freed since it used by utils::log globally
     utils.initTables()
 
     # Setup argv, arguments and their values
@@ -226,9 +227,6 @@ def train_wrapper(model_name, input_file, output, label_prefix, lr, dim, ws,
     # Load the model
     output_bin = output + '.bin'
     model = load_model(output_bin, label_prefix)
-
-    # Free the log & sigmoid tables from the heap
-    utils.freeTables()
 
     # Free the allocated memory
     # The content from PyString_AsString is not deallocated

--- a/test/classifier_test.py
+++ b/test/classifier_test.py
@@ -187,6 +187,12 @@ class TestClassifierModel(unittest.TestCase):
         # Make sure .bin and .vec are generated
         self.assertTrue(path.isfile(output + '.bin'))
 
+        # Test some methods, make sure it works
+        labels = model.predict(['some long long texts'])
+        self.assertTrue(type(labels) == type([]))
+        labels = model.predict_proba(['some long long texts'])
+        self.assertTrue(type(labels) == type([]))
+
     def test_classifier_test(self):
         # Read the test result from fasttext(1) using the same classifier model
         precision_at_one = 0.0


### PR DESCRIPTION
The log tabels is deallocated in `train_wrapper` but it used by `model::findKBest` so it cause the `segfault` error. This patch fix this bug.

New asserts also added to the test to make sure this works as expected