### PR TITLE
improves check word in vocab performance

### DIFF
--- a/fasttext/model.py
+++ b/fasttext/model.py
@@ -6,7 +6,7 @@ from numpy.linalg import norm
 class WordVectorModel(object):
     def __init__(self, model, words):
         self._model = model
-        self.words = words
+        self.words = set(words)
         self.dim = model.dim
         self.ws = model.ws
         self.epoch = model.epoch


### PR DESCRIPTION
Right now, `WordVectorModel.__contains__` uses a list (`self.words`) to check the presence of a word in vocab. This is pretty inefficient for even moderately large vocabs - brief profiling results attached below

![1](https://cloud.githubusercontent.com/assets/1329532/18269049/154bb288-7444-11e6-80f5-1067150b80ac.png)

With current implementation:
![2](https://cloud.githubusercontent.com/assets/1329532/18269048/15498198-7444-11e6-9f0d-5aab1df79bc2.png)

With a set:
![3](https://cloud.githubusercontent.com/assets/1329532/18269047/15481c7c-7444-11e6-93d0-17f68322b0eb.png)

This is with a vocab of ~15k

Right now, words isn't exposed via an interface except the constructor, so hopefully the change should have minimal impact. Otherwise, we can always store a separate property instead of simply using `self.words`

