### PR TITLE
Remove empty strings that throw an IndexError. 

### DIFF
--- a/fasttext/model.py
+++ b/fasttext/model.py
@@ -61,6 +61,7 @@ class SupervisedModel(object):
 
     def predict(self, texts, k=1):
         all_labels = []
+	texts = filter(None,texts)
         for text in texts:
             if text[-1] != '\n':
                 text += '\n'
@@ -71,6 +72,7 @@ class SupervisedModel(object):
 
     def predict_proba(self, texts, k=1):
         results = []
+	texts = filter(None,texts)
         for text in texts:
             if text[-1] != '\n':
                 text += '\n'


### PR DESCRIPTION
I was using this library in my own work and saw that empty strings were causing an IndexError. Since empty strings really can't be classified into classes I thought adding this to the code could make it slightly better. 