### PR TITLE
fixed ifstream not loading binary files correctly on msvc

### DIFF
--- a/fasttext/interface.cc
+++ b/fasttext/interface.cc
@@ -285,7 +285,7 @@ void trainWrapper(int argc, char **argv, int silent)
  * data is private in FastText class */
 void loadModelWrapper(std::string filename, FastTextModel& model)
 {
-    std::ifstream ifs(filename);
+    std::ifstream ifs(filename, std::ios_base::in | std::ios_base::binary);
     if (!ifs.is_open()) {
         std::cerr << "interface.cc: cannot load model file ";
         std::cerr << filename << std::endl;


### PR DESCRIPTION
On windows / MSVC the .bin model was loaded without the `std::ios_base::binary` flag which caused almost everything besides training not to work. This fixes it.