### PR TITLE
[WIP] Add Windows wheel support via Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ environment:
 install:
   # We need wheel installed to build wheels
   - "%PYTHON%\\python.exe -m pip install wheel"
+  - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,42 @@
+environment:
+
+  matrix:
+
+    # For Python versions available on Appveyor, see
+    # http://www.appveyor.com/docs/installed-software#python
+    # The list here is complete (excluding Python 2.6, which
+    # isn't covered by this document) at the time of writing.
+
+    - PYTHON: "C:\\Python36-x64"
+
+install:
+  # We need wheel installed to build wheels
+  - "%PYTHON%\\python.exe -m pip install wheel"
+
+build: off
+
+test_script:
+  # Put your test command here.
+  # If you don't need to build C extensions on 64-bit Python 3.3 or 3.4,
+  # you can remove "build.cmd" from the front of the command, as it's
+  # only needed to support those cases.
+  # Note that you must use the environment variable %PYTHON% to refer to
+  # the interpreter you're using - Appveyor does not do anything special
+  # to put the Python version you want to use on PATH.
+  - "build.cmd %PYTHON%\\python.exe setup.py test"
+
+after_test:
+  # This step builds your wheels.
+  # Again, you only need build.cmd if you're building C extensions for
+  # 64-bit Python 3.3/3.4. And you need to use %PYTHON% to get the correct
+  # interpreter
+  - "build.cmd %PYTHON%\\python.exe setup.py bdist_wheel"
+
+artifacts:
+  # bdist_wheel puts your built wheel in the dist directory
+  - path: dist\*
+
+#on_success:
+#  You can use this step to upload your artifacts to a public website.
+#  See Appveyor's documentation for more details. Or you can simply
+#  access your wheels from the Appveyor "artifacts" tab for your build.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,14 +23,14 @@ test_script:
   # Note that you must use the environment variable %PYTHON% to refer to
   # the interpreter you're using - Appveyor does not do anything special
   # to put the Python version you want to use on PATH.
-  - "build.cmd %PYTHON%\\python.exe setup.py test"
+  - "%PYTHON%\\python.exe setup.py test"
 
 after_test:
   # This step builds your wheels.
   # Again, you only need build.cmd if you're building C extensions for
   # 64-bit Python 3.3/3.4. And you need to use %PYTHON% to get the correct
   # interpreter
-  - "build.cmd %PYTHON%\\python.exe setup.py bdist_wheel"
+  - "%PYTHON%\\python.exe setup.py bdist_wheel"
 
 artifacts:
   # bdist_wheel puts your built wheel in the dist directory

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ extensions = [
 
 # Package details
 setup(
-    name='fasttext',
+    name='fasttext_win',
     version='0.8.3',
     author='Bayu Aldi Yansyah',
     author_email='bayualdiyansyah@gmail.com',


### PR DESCRIPTION
Hi - I needed a built copy of this package for my own Windows computer, and figured it may be of general interest. Ignore the `setup.py` file - that was so I could release a separate package to pypi.

The PR is here for reference -- all that's needed is 
- the appveyor.yml file (see changelist here)
- support for a few more python versions (see reference below, simply updating build matrix)
- and potentially a couple of extra build steps to release/upload the built wheel files on successful merge.

If this is of general interest, let me know and I can clean up this PR into something more viable.

For reference, see: 
https://packaging.python.org/guides/supporting-windows-using-appveyor/

